### PR TITLE
修复退出zxing扫码页面后cpu占用依然100%问题

### DIFF
--- a/LBXScan/LBXZXing/ZXingWrapper.m
+++ b/LBXScan/LBXZXing/ZXingWrapper.m
@@ -81,7 +81,7 @@ typedef void(^blockScan)(ZXBarcodeFormat barcodeFormat,NSString *str,UIImage *sc
 - (void)stop
 {
     self.bNeedScanResult = NO;
-    [self.capture stop];
+    [self.capture hard_stop];
     
 }
 


### PR DESCRIPTION
zxing 有两个退出方法 ， 一个 ```stop``` 一个 ```hard_stop```

在```- (void)viewWillDisappear:(BOOL)animated```中退出更适合调用```hard_stop```
#109 
