### PR TITLE
启用闪光灯时, 先判断设备是否支持闪光灯;

### DIFF
--- a/LBXScan/LBXNative/LBXScanNative.m
+++ b/LBXScan/LBXNative/LBXScanNative.m
@@ -260,7 +260,9 @@
 - (void)setTorch:(BOOL)torch {   
     
     [self.input.device lockForConfiguration:nil];
-    self.input.device.torchMode = torch ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
+    if ([self.input.device hasTorch]) {
+        self.input.device.torchMode = torch ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
+    }
     [self.input.device unlockForConfiguration];
 }
 

--- a/LBXScan/LBXZXing/LBXZXCapture.m
+++ b/LBXScan/LBXZXing/LBXZXCapture.m
@@ -177,11 +177,13 @@
 }
 
 - (void)setTorch:(BOOL)torch {
-  _torch = torch;
+    _torch = torch;
 
-  [self.input.device lockForConfiguration:nil];
-  self.input.device.torchMode = self.torch ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
-  [self.input.device unlockForConfiguration];
+    [self.input.device lockForConfiguration:nil];
+    if ([self.input.device hasTorch]) {
+        self.input.device.torchMode = self.torch ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
+    }
+    [self.input.device unlockForConfiguration];
 }
 
 - (void)changeTorch


### PR DESCRIPTION
iPad设备不支持闪光灯, 做一层防御以防崩溃; 