### PR TITLE
修复横屏时扫码需要竖着扫的问题

### DIFF
--- a/LBXScan/LBXZXing/ZXingWrapper.m
+++ b/LBXScan/LBXZXing/ZXingWrapper.m
@@ -126,6 +126,19 @@
     
     AVCaptureVideoPreviewLayer * preview = (AVCaptureVideoPreviewLayer*)self.capture.layer;
        preview.connection.videoOrientation = self.orientation;
+    
+    switch (self.orientation) {
+        case AVCaptureVideoOrientationPortrait:
+        case AVCaptureVideoOrientationPortraitUpsideDown:
+            self.capture.rotation = 90.0f;
+            break;
+        case AVCaptureVideoOrientationLandscapeLeft:
+        case AVCaptureVideoOrientationLandscapeRight:
+            self.capture.rotation = 0.0f;
+            break;
+        default:
+            break;
+    }
 }
 
 - (void)setVideoLayerframe:(CGRect)videoLayerframe


### PR DESCRIPTION
ZXingWrapper的orientation改变后，capture的rotation没跟着变，导致识别时图片可能会拧90度，对此问题进行了修复